### PR TITLE
Upgrade libraries: bootstrap-frontend-play-30 → 10.6.0, bootstrap-backend-play-30 → 10.6.0

### DIFF
--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -2,7 +2,7 @@ import play.sbt.PlayImport._
 import sbt._
 
 object AppDependencies {
-  lazy val bootStrapPlayVersion = "10.5.0"
+  lazy val bootStrapPlayVersion = "10.6.0"
 
   lazy val compile: Seq[ModuleID] = Seq(
     ws,


### PR DESCRIPTION
## Library Upgrades

| Group | Artifact | New Version |
|-------|----------|-------------|
| `uk.gov.hmrc` | `bootstrap-frontend-play-30` | `10.6.0` |
| `uk.gov.hmrc` | `bootstrap-backend-play-30` | `10.6.0` |

_This PR was created automatically by the Library Upgrade Tool._